### PR TITLE
Enriched reported labels

### DIFF
--- a/src/AllureListener.cs
+++ b/src/AllureListener.cs
@@ -35,19 +35,22 @@ namespace Unicorn.AllureAgent
                 };
 
                 string idValue = "-1";
+                List<string> suites = new List<string>();
 
                 if (suiteMethod.MethodType.Equals(SuiteMethodType.Test))
                 {
                     idValue = suiteMethod.Outcome.TestCaseId;
                     labels.Add(Label.Owner(suiteMethod.Outcome.Author));
                     labels.AddRange(testSuite.Tags.Select(tag => Label.Feature(tag)));
-                    labels.AddRange((suiteMethod as Test).Categories.Select(c => Label.Suite(c)));
-                }
-                else
-                {
-                    labels.Add(Label.Suite("Tests without suite"));
+                    suites.AddRange((suiteMethod as Test).Categories);
                 }
 
+                if (!suites.Any())
+                {
+                    suites.Add("Tests without suite");
+                }
+
+                labels.AddRange(suites.Select(s => Label.Suite(s)));
                 labels.Add(new Label() { name = LabelNames.TestCaseId, value = idValue });
 
                 var result = new TestResult

--- a/src/AllureListener.cs
+++ b/src/AllureListener.cs
@@ -11,6 +11,14 @@ namespace Unicorn.AllureAgent
     /// </summary>
     public partial class AllureListener
     {
+        internal static class LabelNames
+        {
+            internal const string TestCaseId = "AS_ID";
+            internal const string Language = "language";
+            internal const string Framework = "framework";
+        }
+
+
         private string testGuid = null;
 
         internal void StartSuiteMethod(SuiteMethod suiteMethod)
@@ -19,24 +27,35 @@ namespace Unicorn.AllureAgent
             {
                 var labels = new List<Label>()
                 {
-                    Label.Owner(suiteMethod.Outcome.Author),
+                    Label.Thread(),
+                    new Label() {name = LabelNames.Language, value = "C#" },
+                    new Label() {name = LabelNames.Framework, value = "Unicorn.TAF" },
                     Label.Host(Environment.MachineName),
-                    Label.Suite(testSuite.Outcome.Name),
                     Label.TestClass(testSuite.GetType().Name),
                     Label.Package(testSuite.GetType().Namespace)
                 };
 
-                foreach (var tag in testSuite.Tags)
+                HashSet<string> categories = (suiteMethod as Test).Categories;
+
+                if (categories.Any())
                 {
-                    labels.Add(Label.Feature(tag));
+                    labels.AddRange(categories.Select(c => Label.Suite(c)));
                 }
+                else
+                {
+                    labels.Add(Label.Suite("Tests without suite"));
+                }
+
+                string idValue = "-1";
 
                 if (suiteMethod.MethodType.Equals(SuiteMethodType.Test))
                 {
-                    labels.AddRange((suiteMethod as Test)
-                        .Categories
-                        .Select(c => new Label() { name = "Category", value = c }));
+                    idValue = suiteMethod.Outcome.TestCaseId;
+                    labels.Add(Label.Owner(suiteMethod.Outcome.Author));
+                    labels.AddRange(testSuite.Tags.Select(tag => Label.Feature(tag)));
                 }
+
+                labels.Add(new Label() { name = LabelNames.TestCaseId, value = idValue });
 
                 var result = new TestResult
                 {
@@ -47,11 +66,7 @@ namespace Unicorn.AllureAgent
                     historyId = suiteMethod.Outcome.Id.ToString(),
                 };
 
-                if (suiteMethod.MethodType.Equals(SuiteMethodType.Test))
-                {
-                    labels.Add(new Label() { name = "AS_ID", value = suiteMethod.Outcome.TestCaseId });
-                    result.testCaseId = suiteMethod.Outcome.TestCaseId;
-                }
+                result.testCaseId = idValue;
 
                 testGuid = suiteMethod.Outcome.Id.ToString();
                 AllureLifecycle.Instance.StartTestCase(testSuite.Outcome.Id.ToString(), result);

--- a/src/AllureListener.cs
+++ b/src/AllureListener.cs
@@ -18,7 +18,6 @@ namespace Unicorn.AllureAgent
             internal const string Framework = "framework";
         }
 
-
         private string testGuid = null;
 
         internal void StartSuiteMethod(SuiteMethod suiteMethod)
@@ -35,17 +34,6 @@ namespace Unicorn.AllureAgent
                     Label.Package(testSuite.GetType().Namespace)
                 };
 
-                HashSet<string> categories = (suiteMethod as Test).Categories;
-
-                if (categories.Any())
-                {
-                    labels.AddRange(categories.Select(c => Label.Suite(c)));
-                }
-                else
-                {
-                    labels.Add(Label.Suite("Tests without suite"));
-                }
-
                 string idValue = "-1";
 
                 if (suiteMethod.MethodType.Equals(SuiteMethodType.Test))
@@ -53,6 +41,11 @@ namespace Unicorn.AllureAgent
                     idValue = suiteMethod.Outcome.TestCaseId;
                     labels.Add(Label.Owner(suiteMethod.Outcome.Author));
                     labels.AddRange(testSuite.Tags.Select(tag => Label.Feature(tag)));
+                    labels.AddRange((suiteMethod as Test).Categories.Select(c => Label.Suite(c)));
+                }
+                else
+                {
+                    labels.Add(Label.Suite("Tests without suite"));
                 }
 
                 labels.Add(new Label() { name = LabelNames.TestCaseId, value = idValue });


### PR DESCRIPTION
Added:
 - `language` (_`C#`_)
 - `framework` (_`Unicorn.TAF`_)
 - `thread`

`AS_ID` is `-1` for suite methods which are not tests

`suite` is filled from test categories, if no categories set, then default _`Tests without suite`_ is used

Next labels are reported for tests ONLY:
 - `owner`
 - `feature`
 - `category`